### PR TITLE
Chroot split

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bramvdbogaerde/go-scp v0.0.0-20200119201711-987556b8bdd7
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-yaml/yaml v2.1.0+incompatible
-	github.com/google/uuid v1.1.1
+	github.com/google/uuid v1.2.0
 	github.com/infra-whizz/wzbox v0.0.0-20210223141646-d2405805b379 // indirect
 	github.com/infra-whizz/wzlib v0.0.0-20200622182529-c99727f3707a
 	github.com/karrick/godirwalk v1.15.6
@@ -15,6 +15,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/sirupsen/logrus v1.5.0
 	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/thoas/go-funk v0.7.0
 	go.starlark.net v0.0.0-20200305232040-dcffbd0efcc1
 	golang.org/x/crypto v0.0.0-20200219234226-1ad67e1f0ef4
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/infra-whizz/wzbox v0.0.0-20210222175233-4f03adb07341 h1:GXfZbtXUbFlmlYSPYPXUjWrNnoNsKAuyU9vvm7VYzEI=
 github.com/infra-whizz/wzbox v0.0.0-20210222175233-4f03adb07341/go.mod h1:xlgKZlmvZUFaQqGdjPsCV+YRVHf/KZsbpxzhkWr/dNU=
 github.com/infra-whizz/wzbox v0.0.0-20210222185935-359494464394 h1:aXVdU5ksu1EKbRlu06JjaKzPyyTgO4nF6LVF2MyO6uw=
@@ -92,6 +94,9 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/thoas/go-funk v0.7.0 h1:GmirKrs6j6zJbhJIficOsz2aAI7700KsU/5YrdHRM1Y=
+github.com/thoas/go-funk v0.7.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
@@ -129,6 +134,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/nanorunners/callers/ansiblecall.go
+++ b/nanorunners/callers/ansiblecall.go
@@ -172,7 +172,7 @@ func (am *AnsibleModule) Call() (map[string]interface{}, error) {
 	var ret map[string]interface{}
 	stdout, stderr, err := am.execModule()
 	if stderr != "" {
-		am.GetLogger().Errorf("Call error:\n%s", stderr)
+		am.GetLogger().Errorf("Ansible call error:\n'%s'", stderr)
 	}
 	if err != nil && stdout == "" && stderr == "" {
 		return nil, err
@@ -239,11 +239,7 @@ func (am *AnsibleModule) execModule() (string, string, error) {
 
 			if err != nil {
 				am.GetLogger().Errorf("Module '%s' failed: %s", exePath, err.Error())
-				am.GetLogger().Debugf("STDOUT:\n%s", stdout.String())
-				am.GetLogger().Debugf("STDERR:\n%s", stderr.String())
 			}
-			am.GetLogger().Debugf("STDOUT:\n%s", stdout.String())
-			am.GetLogger().Debugf("STDERR:\n%s", stderr.String())
 
 			if chrootExit != nil {
 				err = chrootExit()
@@ -282,11 +278,7 @@ func (am *AnsibleModule) execModule() (string, string, error) {
 
 		if err != nil {
 			am.GetLogger().Errorf("Module '%s' failed: %s", exePath, err.Error())
-			am.GetLogger().Debugf("STDOUT:\n%s", stdout.String())
-			am.GetLogger().Debugf("STDERR:\n%s", stderr.String())
 		}
-		am.GetLogger().Debugf("STDOUT:\n%s", stdout.String())
-		am.GetLogger().Debugf("STDERR:\n%s", stderr.String())
 
 		if chrootExit != nil {
 			err = chrootExit()

--- a/nanorunners/localrunner.go
+++ b/nanorunners/localrunner.go
@@ -50,7 +50,7 @@ func (lr *LocalRunner) callShell(args interface{}) ([]RunnerHostResult, error) {
 }
 
 func (lr *LocalRunner) callAnsibleModule(name string, kwargs map[string]interface{}) ([]RunnerHostResult, error) {
-	lr.GetLogger().Debugf("Ansible modules are chrooted to '%s'", lr.chrootPath)
+	lr.GetLogger().Debugf("Module operation context: '%s'", lr.chrootPath)
 	lr.GetLogger().Debugf("Calling external module '%s': %v", name, kwargs)
 	caller := nanocms_callers.NewAnsibleLocalModuleCaller(name).
 		SetStateRoots(lr.stateRoots...).

--- a/nanorunners/results/logdump.go
+++ b/nanorunners/results/logdump.go
@@ -148,7 +148,7 @@ func (rtl *ResultsToLog) ToLog() []*ResultLogEntry {
 							messages = append(messages, &ResultLogEntry{
 								Level: logrus.DebugLevel,
 								Message: fmt.Sprintf("%s introspected direct output:\n%s",
-									moduleId, spew.Sdump(moduleCallResult.Json["msg"])),
+									moduleId, spew.Sdump(moduleCallResult.Json)),
 							})
 						}
 					}


### PR DESCRIPTION
The idea is to specify "root" and then the module is never ran forcibly chrooted, but will deal with the root on its own. E.g. zypper will do `zypper --root .....` instead of being ran as `chroot zypper ....`.